### PR TITLE
Update pack.mcmeta format

### DIFF
--- a/java/data/pack.mcmeta.json
+++ b/java/data/pack.mcmeta.json
@@ -29,7 +29,7 @@
                     "description": "This is 1 for 1.13"
                 },
                 "description": {
-                    "$ref": "./data/pack.mcmeta.json#",
+                    "$ref": "../shared/text_component.json#",
                     "title": "Pack description",
                     "description": "The description for this pack. Any text which doesn't fit on two lines will be removed"
                 }

--- a/java/data/pack.mcmeta.json
+++ b/java/data/pack.mcmeta.json
@@ -29,7 +29,7 @@
                     "description": "This is 1 for 1.13"
                 },
                 "description": {
-                    "type": "string",
+                    "$ref": "./data/pack.mcmeta.json#",
                     "title": "Pack description",
                     "description": "The description for this pack. Any text which doesn't fit on two lines will be removed"
                 }


### PR DESCRIPTION
Description now accepts a text component, not just a string.
Not sure if resource packs also do, but I would assume so.