### PR TITLE
Set the schema version to draft-07

### DIFF
--- a/java/assets/animation.mcmeta.json
+++ b/java/assets/animation.mcmeta.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/Levertion/minecraft-json-schemas/master/java/assets/animation.mcmeta.json",
     "properties": {
         "animation": {

--- a/java/assets/blockstates.json
+++ b/java/assets/blockstates.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/Levertion/minecraft-json-schema/master/java/assets/blockstates.json",
     "type": "object",
     "title": "Blockstates file",

--- a/java/assets/model.json
+++ b/java/assets/model.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/Levertion/minecraft-json-schema/master/java/assets/model.json",
     "type": "object",
     "additionalProperties": false,

--- a/java/assets/pack.mcmeta.json
+++ b/java/assets/pack.mcmeta.json
@@ -1,6 +1,6 @@
 {
     "type": "object",
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/Levertion/minecraft-json-schemas/master/java/data/pack.mcmeta.json",
     "title": "Resource pack information",
     "description": "Information about a resource pack",

--- a/java/assets/sounds.json
+++ b/java/assets/sounds.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/Levertion/minecraft-json-schema/master/java/assets/sounds.json",
     "type": "object",
     "title": "Sound file root",

--- a/java/data/advancement.json
+++ b/java/data/advancement.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/Levertion/minecraft-json-schema/master/java/data/advancement.json",
     "type": "object",
     "additionalProperties": false,

--- a/java/data/loot_table.json
+++ b/java/data/loot_table.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/Levertion/minecraft-json-schemas/master/java/data/loot_table.json",
     "type": "object",
     "title": "Root tag",

--- a/java/data/pack.mcmeta.json
+++ b/java/data/pack.mcmeta.json
@@ -1,6 +1,6 @@
 {
     "type": "object",
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/Levertion/minecraft-json-schemas/master/java/data/pack.mcmeta.json",
     "title": "Resource pack information",
     "description": "Information about a resource pack",

--- a/java/data/recipe.json
+++ b/java/data/recipe.json
@@ -1,6 +1,6 @@
 {
     "$comment": "Some descriptions in this file are from https://github.com/skylinerw/guides/blob/master/java/recipes.md",
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/Levertion/minecraft-json-schemas/master/java/data/recipe.json",
     "type": "object",
     "title": "Root tag",

--- a/java/data/tags/block.json
+++ b/java/data/tags/block.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/Levertion/minecraft-json-schemas/master/java/data/tags/block.json",
     "type": "object",
     "title": "Root tag",

--- a/java/data/tags/entity_type.json
+++ b/java/data/tags/entity_type.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/Levertion/minecraft-json-schemas/master/java/data/tags/entity_type.json",
     "type": "object",
     "title": "Root tag",

--- a/java/data/tags/fluid.json
+++ b/java/data/tags/fluid.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/Levertion/minecraft-json-schemas/master/java/data/tags/fluid.json",
     "type": "object",
     "title": "Root tag",

--- a/java/data/tags/function.json
+++ b/java/data/tags/function.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/Levertion/minecraft-json-schemas/master/java/data/tags/function.json",
     "type": "object",
     "title": "Root tag",

--- a/java/data/tags/item.json
+++ b/java/data/tags/item.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/Levertion/minecraft-json-schemas/master/java/data/tags/item.json",
     "type": "object",
     "title": "Root tag",

--- a/java/pack.mcmeta_either.json
+++ b/java/pack.mcmeta_either.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/Levertion/minecraft-json-schemas/master/java/pack.mcmeta_either.json",
     "title": "An unknown pack.mcmeta",
     "description": "This is either for a resource pack or a data pack",


### PR DESCRIPTION
This PR changes the value of `"$schema"` for every JSON file under `java` to "http://json-schema.org/draft-07/schema", as draft-07 appears to be the version these schemas were written using (that or draft-06, which draft-07 is compatible with).

Currently, the schemas list their meta-schema as `http://json-schema.org/schema#`. This makes several JSON schema validators (including [everit.org's](https://github.com/everit-org/json-schema) and [Justify](https://github.com/leadpony/justify)) complain, as they use that value to extract version info. This PR should make these schemas work with those libraries (and presumably others).

Have a good day!